### PR TITLE
Changes to All and Any

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 **/packages
 FunctionalLibrary/NuGet.exe
 *.nupkg
+/.vs/FunctionalLibrary/v17/TestStore/0

--- a/FunctionalLibrary/FList Functions.cs
+++ b/FunctionalLibrary/FList Functions.cs
@@ -297,7 +297,7 @@ namespace MetalUp.FunctionalLibrary
         #region Higher-order functions: Map, Filter, Reduce, Any
         public static bool Any<T>(Func<T, bool> func, FList<T> list)
         {
-            return !IsEmpty(Filter(func, list));
+            return IsEmpty(list) ? false : func(list.Head) ? true : Any(func, list.Tail);
         }
         public static bool Any(Func<char, bool> func, string str)
         {
@@ -306,7 +306,7 @@ namespace MetalUp.FunctionalLibrary
 
         public static bool All<T>(Func<T, bool> func, FList<T> list)
         {
-            return !IsEmpty(list) && Length(Filter(func, list)) == Length(list);
+            return IsEmpty(list) ? true : !func(list.Head) ? false : All(func, Tail(list));
         }
         public static bool All(Func<char, bool> func, string str)
         {

--- a/FunctionalLibraryTest/All.cs
+++ b/FunctionalLibraryTest/All.cs
@@ -43,7 +43,7 @@ namespace FunctionalLibraryTest
         {
             var list = FList.Empty<int>();
             var all = FList.All(i => i > 3, list);
-            Assert.IsFalse(all);
+            Assert.IsTrue(all);
         }
 
         [TestMethod]
@@ -83,7 +83,7 @@ namespace FunctionalLibraryTest
         {
             var list = "";
             var all = FList.All(i => i > '3', list);
-            Assert.IsFalse(all);
+            Assert.IsTrue(all);
         }
     }
 }


### PR DESCRIPTION
`All` and `Any` now short-circuit and return a Boolean result as soon as possible., e.g., `All(i => i % 2 == 0, EnumFrom(1))`  will return `false` after having only tested the first element of the range from `1` to `Int32.MaxValue`.

`All` will return `true` when used on an empty list, e.g., `All(i => i % 2 == 0, Flist.Empty<int>()` returns `true`.

